### PR TITLE
Fix reset prop documentation example

### DIFF
--- a/hyperdiv_docs/pages/guide/component_props.py
+++ b/hyperdiv_docs/pages/guide/component_props.py
@@ -132,10 +132,10 @@ def component_props():
 
             ```py
             slider = hd.slider()
-            text_input = hd.text_input(value=slider.value)
+            hd.text_input(value=slider.value)
             reset_button = hd.button("Reset")
             if reset_button.clicked:
-                text_input.reset_prop("value")
+                slider.reset_prop("value")
             ```
 
             This design strikes a balance between being able to build


### PR DESCRIPTION
Small fix for the documents, basically this block:

```python
slider = hd.slider()
text_input = hd.text_input(value=slider.value)
reset_button = hd.button("Reset")
if reset_button.clicked:
    text_input.reset_prop("value")
```

Has no effect, since tries to reset the value of the `text_input` instead the actual slider. 

Changed to:
```python
slider = hd.slider()
hd.text_input(value=slider.value)
reset_button = hd.button("Reset")
if reset_button.clicked:
    slider.reset_prop("value")
```