### PR TITLE
Extractor refactor

### DIFF
--- a/hyperdiv_docs/docs_metadata.py
+++ b/hyperdiv_docs/docs_metadata.py
@@ -1,0 +1,36 @@
+import os
+import json
+import pathlib
+
+metadata = None
+json_path = pathlib.Path(os.path.dirname(__file__), "docs_metadata.json")
+
+
+def get_docs_metadata():
+    global metadata
+
+    if metadata:
+        return metadata
+
+    if json_path.exists():
+        with open(json_path) as f:
+            metadata = json.loads(f.read())
+            return metadata
+    else:
+        from .extractor.main import extract
+
+        metadata = extract()
+        return metadata
+
+
+def create_docs_metadata():
+    """
+    (Re)-creates the stored JSON file containing docs metadata.
+    """
+    from .extractor.main import extract
+
+    if json_path.exists():
+        os.unlink(json_path)
+    data = extract()
+    with open(json_path, "w") as f:
+        f.write(json.dumps(data, indent=2))

--- a/hyperdiv_docs/extractor/main.py
+++ b/hyperdiv_docs/extractor/main.py
@@ -1,41 +1,15 @@
-import os
-import json
 import inspect
-import pathlib
 import hyperdiv as hd
 from hyperdiv.prop_types import HyperdivType
 from .extractor import Extractor
-
-extracted = None
-json_path = pathlib.Path(os.path.dirname(__file__), "extracted.json")
 
 
 def extract():
     """
     Extracts metadata from the Hyperdiv repo, which is used to
     dynamically render the docs components and prop types pages.
-
-    If a json file exists at `json_path`, this function will load that
-    json file. If not, it creates an Extractor and extracts docs
-    metadata from the hyperdiv repo, starting with all the components
-    and types exported by hyperdiv at the top level.
-
-    The output is cached in the global variable `extracted` and
-    returned on subsequent calls.
     """
-    global extracted
 
-    # If globally cached, return.
-    if extracted:
-        return extracted
-
-    # If the json file exists, load it, cache it, and return.
-    if json_path.exists():
-        with open(json_path) as f:
-            extracted = json.loads(f.read())
-            return extracted
-
-    # Otherwise extract metadata from the Hyperdiv repo.
     ctx = Extractor()
 
     # Iterate over all the attributes exported by `hyperdiv`
@@ -78,17 +52,4 @@ def extract():
     for typ in ctx.types.values():
         ctx.extract_prop_type(typ)
 
-    # Cache the output
-    extracted = ctx.output
-    return extracted
-
-
-def create_json_file():
-    """
-    (Re)-creates the stored JSON file containing docs metadata.
-    """
-    if os.path.exists(json_path):
-        os.unlink(json_path)
-    data = extract()
-    with open(json_path, "w") as f:
-        f.write(json.dumps(data, indent=2))
+    return ctx.output

--- a/hyperdiv_docs/pages/reference/components.py
+++ b/hyperdiv_docs/pages/reference/components.py
@@ -3,7 +3,7 @@ from ...router import router
 from ...code_examples import docs_markdown
 from ...utils import render_value
 from ...page import page
-from ...extractor.main import extract
+from ...docs_metadata import get_docs_metadata
 
 
 def render_methods(methods):
@@ -79,7 +79,7 @@ def render_slots(slots):
 
 @router.route("/reference/components/{component_name}")
 def reference_component(component_name):
-    data = extract()
+    data = get_docs_metadata()
     component = data["components"].get(component_name)
     if not component:
         router.render_not_found()

--- a/hyperdiv_docs/pages/reference/prop_types.py
+++ b/hyperdiv_docs/pages/reference/prop_types.py
@@ -2,12 +2,12 @@ import hyperdiv as hd
 from ...router import router
 from ...code_examples import docs_markdown
 from ...page import page
-from ...extractor.main import extract
+from ...docs_metadata import get_docs_metadata
 
 
 @router.route("/reference/prop-types")
 def prop_types():
-    data = extract()
+    data = get_docs_metadata()
 
     top_level_types = []
     concrete_types = []
@@ -97,7 +97,7 @@ def prop_type(prop_type_name):
             )
         return
 
-    data = extract()
+    data = get_docs_metadata()
     if prop_type_name not in data["prop_types"]:
         router.render_not_found()
         return


### PR DESCRIPTION
This PR refactors the docs app so the extractor isn't imported at all when a built docs metadata json file already exists. This allows the built PyPI bundle to not depend on the extractor's import dependencies.

Partially addresses https://github.com/hyperdiv/hyperdiv/issues/8 and https://github.com/hyperdiv/hyperdiv/issues/5