### PR TITLE
fix reset_prop example

### DIFF
--- a/hyperdiv_docs/pages/guide/component_props.py
+++ b/hyperdiv_docs/pages/guide/component_props.py
@@ -135,7 +135,7 @@ def component_props():
             text_input = hd.text_input(value=slider.value)
             reset_button = hd.button("Reset")
             if reset_button.clicked:
-                text_input.reset_prop("value")
+                slider.reset_prop("value")
             ```
 
             This design strikes a balance between being able to build


### PR DESCRIPTION
Noticed that the prop reset example didn't work.

<img width="1126" alt="Screenshot 2024-02-24 at 4 15 53 PM" src="https://github.com/hyperdiv/hyperdiv-docs/assets/5140829/6e8557b2-41e4-4a66-be7e-b0308c10a344">
