### PR TITLE
Extending Hyperdiv

### DIFF
--- a/assets/iframe-example.html
+++ b/assets/iframe-example.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+  Hello, this is an iframe!
+  </body>
+</html>

--- a/hyperdiv_docs/code_examples.py
+++ b/hyperdiv_docs/code_examples.py
@@ -60,7 +60,7 @@ def code_example(code, code_to_execute=None):
         with hd.box(grow=1, basis=0, min_width=18):
             with hd.box(padding=1, gap=1):
                 if state.error:
-                    hd.text(f"Error: {state.error}", font_color="red")
+                    hd.markdown(f"`Error: {state.error}`", font_color="red")
                     if hd.button("Reset", size="small").clicked:
                         state.error = None
                 else:

--- a/hyperdiv_docs/menu.py
+++ b/hyperdiv_docs/menu.py
@@ -16,7 +16,12 @@ from .pages.guide.using_the_app_template import using_the_app_template
 from .pages.guide.static_assets import static_assets
 from .pages.guide.deploying import deploying
 from .pages.guide.matplotlib_charts import matplotlib_charts
-from .pages.guide.plugins import plugins
+
+from .pages.extending_hyperdiv.overview import overview as extending_overview
+from .pages.extending_hyperdiv.plugins import plugins
+from .pages.extending_hyperdiv.custom_assets import custom_assets
+from .pages.extending_hyperdiv.built_in_components import built_in_components
+from .pages.extending_hyperdiv.new_components import new_components
 
 from .pages.reference.components import components
 from .pages.reference.env_variables import env_variables
@@ -45,8 +50,14 @@ menu = {
         "Using The App Template": {"href": using_the_app_template.path},
         "Matplotlib Charts": {"href": matplotlib_charts.path},
         "Static Assets": {"href": static_assets.path},
-        "Building Custom Components": {"href": plugins.path},
         "Deploying Hyperdiv": {"href": deploying.path},
+    },
+    "Extending Hyperdiv": {
+        "Overview": {"href": extending_overview.path},
+        "Building Plugins": {"href": plugins.path},
+        "Loading Custom Assets": {"href": custom_assets.path},
+        "Extending Built-In Components": {"href": built_in_components.path},
+        "Creating New Components": {"href": new_components.path},
     },
     "Reference": {
         "Hyperdiv API": {"href": components.path},

--- a/hyperdiv_docs/pages/extending_hyperdiv/built_in_components.py
+++ b/hyperdiv_docs/pages/extending_hyperdiv/built_in_components.py
@@ -1,0 +1,103 @@
+import hyperdiv as hd
+from ...router import router
+from ...page import page
+from ...code_examples import docs_markdown
+
+
+@router.route("/extending-hyperdiv/built-in-components")
+def built_in_components():
+    with page() as p:
+        p.title("# Extending Built-In Components")
+
+        docs_markdown(
+            """
+
+            Hyperdiv built-in components can be extended with new
+            style props. Also, if a built-in style prop doesn't expose
+            CSS attributes that you need, you can override/replace
+            that prop with a prop that does.
+
+            Hyperdiv's prop and type system enables defining props
+            that are compiled to CSS and applied to the component in
+            the browser. For example, we can create a new component
+            type that extends @component(box) with an
+            [opacity](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity)
+            prop:
+
+            ```py
+            class opacity_box(hd.box):
+                opacity = hd.Prop(
+                    hd.CSSField(
+                        "opacity",
+                        hd.Optional(hd.ClampedFloat(0, 1))
+                    ),
+                    None
+                )
+
+            with opacity_box(
+                opacity=0.3,
+                border="1px solid green",
+                padding=1,
+                gap=1,
+            ) as box:
+                hd.text("A low-opacity box.")
+                hd.button("A button")
+
+            ```
+
+            Hyperdiv provides a type, @prop_type(CSSField), that
+            enables defining new CSS attributes. In the example above,
+            we define a new prop, `opacity`. Its type,
+            `CSSField("opacity", hd.Optional(hd.ClampedFloat(0, 1)))`,
+            specifies that
+
+            1. this prop will be compiled to CSS
+            2. the CSS attribute name is `"opacity"`
+            3. the allowed values are floats between 0 and 1. The
+               value of the prop will be rendered directly in the CSS
+               `opacity` field.
+
+            The CSS `opacity: 0.3;` will be added to instances of this
+            component.
+
+            CSS props work like normal Hyperdiv props and can be read
+            and mutated by Python code. For example, we can control
+            the box opacity with a slider:
+
+            ```py
+            class opacity_box(hd.box):
+                opacity = hd.Prop(
+                    hd.CSSField(
+                        "opacity",
+                        hd.Optional(hd.ClampedFloat(0, 1))
+                    ),
+                    None
+                )
+
+            opacity = hd.slider(
+                min_value=0,
+                max_value=1,
+                value=1,
+                step=0.01
+            )
+
+            with opacity_box(
+                opacity=opacity.value,
+                border="1px solid green",
+                padding=1,
+                gap=1,
+            ) as box:
+                hd.text("Drag the slider to change the opacity.")
+                hd.button("A button")
+
+            ```
+
+            Note that when the value of a CSS prop is `None`, its
+            corresponding CSS field will not be sent to the browser at
+            all. `None` corresponds to default browser behavior.
+
+            The props defined by @component(Styled), from which most
+            Hyperdiv components inherit, are defined in this way.
+
+            """
+        )

--- a/hyperdiv_docs/pages/extending_hyperdiv/custom_assets.py
+++ b/hyperdiv_docs/pages/extending_hyperdiv/custom_assets.py
@@ -1,0 +1,27 @@
+import hyperdiv as hd
+from ...router import router
+from ...page import page
+from ...code_examples import docs_markdown
+
+
+@router.route("/extending-hyperdiv/custom-assets")
+def custom_assets():
+    with page() as p:
+        p.title("# Loading Custom Assets")
+
+        docs_markdown(
+            """
+
+            Hyperdiv can be extended by loading custom JS and CSS at
+            the top level of the app. For example, you can [set up
+            Google
+            Analytics](https://www.w3schools.com/howto/howto_google_analytics.asp)
+            for your app, which involves adding Google's custom
+            Javascript tags to the app's top-level. Or, load your own
+            custom Javascript that runs every time the app is loaded.
+
+            To learn how to load custom assets at the top level, see
+            the documentation for @component(index_page).
+
+            """
+        )

--- a/hyperdiv_docs/pages/extending_hyperdiv/new_components.py
+++ b/hyperdiv_docs/pages/extending_hyperdiv/new_components.py
@@ -1,0 +1,64 @@
+import hyperdiv as hd
+from ...router import router
+from ...page import page
+from ...code_examples import docs_markdown
+
+
+@router.route("/extending-hyperdiv/new-components")
+def new_components():
+    with page() as p:
+        p.title("# Creating New Components")
+
+        docs_markdown(
+            """
+
+            In addition to being able to extend existing components
+            with custom CSS props, you can create simple components
+            targeting HTML tags that are currently unsupported by core
+            Hyperdiv. Note that this technique only works when you
+            don't need to run custom Javascript. If you need custom
+            Javascript, build a [plugin](/extending-hyperdiv/plugins).
+
+            For example, Hyperdiv does not include a built-in
+            [`iframe`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
+            component, but we can create one:
+
+            ```py
+            class iframe(hd.Component, hd.Styled):
+                _tag = "iframe"
+
+                src = hd.Prop(hd.PureString)
+
+            iframe(
+                src="/assets/iframe-example.html",
+                border="1px solid neutral",
+                height=10,
+            )
+            ```
+
+            We create a new component by inheriting from Hyperdiv's
+            component base class, @component(Component). Hyperdiv
+            expects a component's HTML tag to be set using the `_tag`
+            class variable. In this case the tag is `iframe`, causing
+            Hyperdiv to render this component in the browser using an
+            `<iframe>` tag.
+
+            In the example above, we also inherit from
+            @component(Styled), allowing us to use style props to
+            style the outer `<iframe>` container with style props like
+            `width` and `border`.
+
+            Iframes work by loading a web page specified by the `src`
+            attribute, so we define a string prop named `src`.
+
+            The example above will be rendered in the browser as:
+
+            ```html
+            <iframe id="..." src="/assets/iframe-example.html"></iframe>
+            ```
+
+            Obviously, additional props can be defined, targeting
+            additional HTML attributes supported by `iframe`.
+
+            """
+        )

--- a/hyperdiv_docs/pages/extending_hyperdiv/overview.py
+++ b/hyperdiv_docs/pages/extending_hyperdiv/overview.py
@@ -1,0 +1,39 @@
+import hyperdiv as hd
+from ...router import router
+from ...page import page
+
+
+@router.route("/extending-hyperdiv")
+def overview():
+    with page() as p:
+        p.title("# Extending Hyperdiv")
+
+        hd.markdown(
+            """
+
+            Hyperdiv can be extended in multiple ways, with new
+            functionality that isn't already built-in.
+
+            The sub-sections of this part of the documentation explore
+            the various ways Hyperdiv can be extended with new
+            functionality:
+
+            * [Building Plugins](/extending-hyperdiv/plugins) -
+              building new, self-contained, reusable components with
+              custom Javascript, CSS, and other assets.
+
+            * [Loading Custom Assets](/extending-hyperdiv/assets) -
+              Loading custom Javascript and CSS assets into the
+              top-level application.
+
+            * [Extending Built-In
+              Components](/extending-hyperdiv/built-in-components) -
+              Subclassing and extending existing Hyperdiv components.
+
+            * [Creating New
+              Components](/extending-hyperdiv/new-components) - An
+              alternative way to define new, simple components without
+              building plugins.
+
+            """
+        )

--- a/hyperdiv_docs/pages/extending_hyperdiv/plugins.py
+++ b/hyperdiv_docs/pages/extending_hyperdiv/plugins.py
@@ -1,0 +1,436 @@
+import hyperdiv as hd
+from ...router import router
+from ...page import page
+from ...code_examples import docs_markdown
+
+
+@router.route("/extending-hyperdiv/plugins")
+def plugins():
+    with page() as p:
+        p.title("# Building Plugins")
+
+        docs_markdown(
+            """
+
+            Hyperdiv provides a @component(Plugin) base class that can
+            be subclassed to create custom components with custom
+            Javascript, CSS, and other assets, such as images, text
+            files, etc.
+
+            Plugins work like built-in Hyperdiv components. They can
+            define props, and when the props are updated by the Python
+            app, the updates are sent to the browser. And when the
+            browser updates props, they are automatically updated on
+            the Python side.
+
+            Plugin instances are wrapped in [Web
+            Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). As
+            such, plugin CSS is naturally isolated to the plugin, and
+            does not interfere with other CSS in the app. However,
+            plugin Javascript assets are *not isolated*. They are
+            inserted in the global `<head>` tag of the Hyperdiv
+            app. As such, plugin Javascript assets should be careful
+            to not pollute the global scope or modify other objects in
+            the global scope.
+
+            A plugin can be instantiated multiple times in the same
+            app, and each plugin instance has its own independent
+            state.
+
+            A plugin has two parts:
+
+            1. A Python class that inherits from @component(Plugin)
+               and defines the plugin's props as well as the plugin's
+               static assets, so Hyperdiv can load them in the
+               browser.
+
+            2. The plugin's assets. One of the provided assets is a
+               special piece of Javascript that uses the Hyperdiv
+               Javascript API to register a plugin with the Hyperdiv
+               frontend.
+
+            """
+        )
+
+        p.heading("## Defining a Plugin")
+
+        docs_markdown(
+            """
+
+            We will build a basic counter plugin that renders a count
+            and a button that increments the count by 1 when
+            clicked. The plugin stores the count in a `count` prop
+            that can be read and written in Python.
+
+            The counter plugin implementation is available
+            [here](https://github.com/hyperdiv/hyperdiv-docs/tree/main/hyperdiv_docs/demos/counter_plugin).
+
+            Here's the plugin's Python definition:
+
+            ```py-nodemo
+            import os
+            import hyperdiv as hd
+
+            class counter(hd.Plugin):
+                _assets_root = os.path.join(os.path.dirname(__file__), "assets")
+                _assets = ["counter.css", "counter.js"]
+
+                count = hd.Prop(hd.Int, 0)
+            ```
+
+            The directory structure of this plugin looks like this:
+
+            ```
+            counter_plugin/
+                __init__.py
+                counter.py
+                assets/
+                    counter.css
+                    counter.js
+            ```
+
+            `counter.py` contains the Python code above and defines
+            the plugin. The `assets` directory contains the Javascript
+            and CSS assets of the plugin. `counter.js` contains the
+            plugin's HTML/Javascript implementation and the code that
+            registers the plugin with the Hyperdiv Javascript
+            frontend. `counter.css` styles the plugin.
+
+            """
+        )
+
+        p.heading("### Local Assets")
+
+        docs_markdown(
+            """
+
+            If the plugin provides local asset files, it must define the
+            class variable `_assets_root`. This is the root directory
+            where the plugin's assets are stored. In the code above,
+            `os.path.join(os.path.dirname(__file__), "assets")` means
+            "the directory named `assets` in the same directory as
+            this Python module."
+
+            Then, the plugin specifies its static assets in the
+            `_assets` class variable. This is a list of paths,
+            relative to the assets root.
+
+            The `_assets` variable supports Python
+            [glob](https://docs.python.org/3/library/glob.html)
+            syntax, so we could rewrite the plugin like this:
+
+            ```py-nodemo
+            import os
+            import hyperdiv as hd
+
+            class counter(hd.Plugin):
+                _assets_root = os.path.join(os.path.dirname(__file__), "assets")
+                _assets = ["*"]
+
+                count = hd.Prop(hd.Int, 0)
+            ```
+
+            Using `glob` syntax, `"*"` means "include all the files in
+            the assets directory". Other examples using glob syntax:
+
+            ```py-nodemo
+            # All the .js files, and all the .css files:
+            _assets = ["*.js", "*.css"]
+
+            # Recursively include all the .js and .css files in all
+            # subdirectories:
+            _assets = ["**/*.js", "**/*.css"]
+
+            # Recursively include all the .js files from the `js`
+            # subdirectory, and all the .css files from the `css`
+            # subdirectory:
+            _assets = ["js/**/*.js", "css/**/*.css"]
+            ```
+            """
+        )
+
+        p.heading("### Remote Assets")
+
+        docs_markdown(
+            """
+
+            In addition to local assets, a plugin can load remote
+            assets. For example, a plugin for
+            [Leaflet](https://leafletjs.com) could look like this:
+
+            ```py-nodemo
+            class leaflet(hd.Plugin):
+                _assets_root = os.path.join(os.path.dirname(__file__), "assets")
+                _assets = [
+                    "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css",
+                    "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js",
+                    "leaflet-plugin.js"
+                ]
+                # ...
+            ```
+
+            This plugin will load Leaflet's CSS and Javascript bundles
+            remotely from `unpkg.com`, and then provide the plugin
+            registration in the local asset `leaflet-plugin.js`.
+
+            More about this Leaflet plugin [below](#a-leaflet-plugin).
+
+            """
+        )
+
+        p.heading("### Nonstandard File Extensions")
+
+        docs_markdown(
+            """
+
+            When loading a local or remote asset file, Hyperdiv infers
+            its type from its extension. Hyperdiv recognizes the
+            extensions `.css` for CSS files and `.js` for Javascript
+            files.
+
+            If a file does not have one of these extensions, Hyperdiv
+            will raise an error.
+
+            If your plugin contains Javascript or CSS files with a
+            different extension, you can use `hd.Plugin.css_link` and
+            `hd.Plugin.js_link` to tell Hyperdiv whether a file is a
+            CSS file or a Javascript file:
+
+            ```py-nodemo
+            class my_plugin(hd.Plugin):
+                # ...
+                _assets = [
+                    # A CSS asset
+                    hd.Plugin.css_link("https://foo.com/bar.style")
+                    # A Javascript asset
+                    hd.Plugin.js_link("foo.stuff")
+                ]
+            ```
+
+            """
+        )
+
+        p.heading("## Registering a Plugin in Javascript")
+
+        docs_markdown(
+            """
+
+            The Hyperdiv frontend exports a function,
+            `window.hyperdiv.registerPlugin`, that a plugin must use
+            to register itself with Hyperdiv.
+
+            A plugin *must* provide a Javascript asset that registers
+            the plugin with Hyperdiv. If the registration is missing,
+            attempting to use a plugin will cause Hyperdiv to crash
+            with Javascript errors.
+
+            The registration looks like this:
+
+            ```js
+            window.hyperdiv.registerPlugin(pluginName, registrationFunction);
+            ```
+
+            By default, the `pluginName` is the name of the Python
+            class that defines the plugin. In our counter example, the
+            plugin name would be `"counter"`. A plugin can provide an
+            explicit name by setting the `_name` class variable:
+
+            ```py-nodemo
+            class my_counter(hd.Plugin):
+                _name = "counter"
+                ...
+            ```
+
+            `registrationFunction` is a function that takes a single
+            parameter, a plugin context object, and sets up the plugin
+            instance.
+
+            """
+        )
+
+        p.heading("### The Plugin Context Object")
+
+        docs_markdown(
+            """
+
+            When you instantiate a plugin in Python, the Hyperdiv
+            frontend will invoke the registration function and pass it
+            an object with the following attributes and methods:
+
+            **Attributes:**
+
+            * `domElement` - The DOM element that this plugin instance
+              should mount into. This is the plugin wrapper's [shadow
+              root](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot).
+
+            * `initialProps` - The prop values with which the plugin
+              was instantiated in Python. This is a dictionary that
+              maps prop names (the names of the plugin's props as
+              defined in Python) to their values.
+
+            * `assetsRoot` - The root path from which the plugin's
+              assets are served. The plugin can use this path to load
+              additional assets, like images, text files, etc.
+
+            **Methods:**
+
+            * `onPropUpdate(callback)` - Registers a prop update
+              handler, to handle incoming prop updates from
+              Python. The callback will be called with the arguments
+              `(propName, propValue)`, with the name and value of the
+              prop that was updated.
+
+            * `updateProp(propName, propValue)` - Sends a prop update
+              to Python.
+
+            Note that when a plugin calls `ctx.updateProp(propName,
+            propValue)` to tell Python to update a prop, this update
+            *will not* be echoed back to the plugin. That is, the
+            update callback registered with `ctx.onPropUpdate()` will
+            not be called for this particular update. Therefore the
+            plugin should update its own internal state to reflect
+            the update, before sending it to Python.
+
+            """
+        )
+
+        p.heading("## Counter Implementation")
+
+        docs_markdown(
+            """
+
+            Here are the contents of `counter.js`, which implements
+            and registers our counter plugin:
+
+            ```js
+            window.hyperdiv.registerPlugin("counter", (ctx) => {
+              let count = 0;
+              const button = document.createElement("button");
+              button.innerText = "Increment";
+              const countDiv = document.createElement("div");
+
+              const updateCount = (newCount) => {
+                count = newCount;
+                countDiv.innerText = count;
+              };
+
+              // On click, increment the count and send the updated
+              // prop value to Python:
+              button.addEventListener("click", () => {
+                updateCount(count + 1);
+                ctx.updateProp("count", count);
+              });
+
+              // Handle incoming prop updates from Python. We ignore
+              // `propName` because there is only one prop, "count".
+              ctx.onPropUpdate((propName, propValue) => {
+                updateCount(propValue);
+              });
+
+              // Add the dom elements to the shadow root.
+              ctx.domElement.appendChild(button);
+              ctx.domElement.appendChild(countDiv);
+
+              // Initialize the plugin with the initial count.
+              updateCount(ctx.initialProps.count);
+            });
+            ```
+
+            Here is the plugin in action:
+
+            ```py
+            counter()
+            ```
+
+            We can initialize, read, and write the `count` prop from
+            Python. We can also style the plugin's outer container,
+            since @component(Plugin) inherits from @component(Styled).
+
+            ```py
+            c = counter(
+                count=30,
+                padding=1,
+                border="1px solid neutral-100",
+                background_color="neutral-50",
+                border_radius="large"
+            )
+
+            hd.markdown('**Prop access in Python**:')
+
+            hd.text(c.count)
+            if hd.button("Increment").clicked:
+                c.count += 1
+            if hd.button("Decrement").clicked:
+                c.count -= 1
+
+            """
+        )
+
+        p.heading("## Using Shoelace In Plugins")
+
+        docs_markdown(
+            """
+
+            All the [Shoelace](https://shoelace.style) components and
+            Shoelace CSS variables used by Hyperdiv are available to
+            plugins.
+
+            For example, a plugin could create a Shoelace button like
+            this:
+
+            ```js
+            const button = document.createElement("sl-button")
+            ```
+
+            When styling elements in plugins, Shoelace's CSS variables
+            can be used. For example:
+
+            ```css
+            .my-class {
+                border-radius: var(--sl-border-radius-large);
+                background-color: var(--sl-color-blue-100);
+            }
+            ```
+
+            """
+        )
+
+        p.heading("## A Leaflet Plugin")
+
+        docs_markdown(
+            """
+
+            Finally, here is a barebones [Leaflet
+            plugin](https://github.com/hyperdiv/hyperdiv-docs/tree/main/hyperdiv_docs/demos/leaflet_plugin)
+            for the [Leaflet](https://leafletjs.com) map library,
+            which exposes `lat`, `lng`, and `zoom` props.
+
+            In this example, we instantiate the plugin and render a
+            list of controls below it, to modify its props from
+            Python.
+
+            ```py
+            leaf = leaflet(
+                # NYC:
+                lat=40.713955826286046,
+                lng=-73.99944305419923,
+                zoom=14
+            )
+
+            with hd.hbox(gap=1, justify="center"):
+                if hd.icon_button("plus").clicked:
+                    leaf.zoom += 1
+                if hd.icon_button("dash").clicked:
+                    leaf.zoom -= 1
+                if hd.icon_button("arrow-up").clicked:
+                    leaf.lat += 0.01
+                if hd.icon_button("arrow-down").clicked:
+                    leaf.lat -= 0.01
+                if hd.icon_button("arrow-left").clicked:
+                    leaf.lng -= 0.01
+                if hd.icon_button("arrow-right").clicked:
+                    leaf.lng += 0.01
+
+            ```
+            """
+        )


### PR DESCRIPTION
This PR adds a docs section named "Extending Hyperdiv", documenting the various ways Hyperdiv can be extended with custom CSS, JS, and new components.

The "Plugins" section is moved from the Guide section to this new section.